### PR TITLE
Stat::Export::Csv exposes the csv data fields not always in the same order within the same extraction

### DIFF
--- a/cfg/plugins/EPrints/Plugin/Stats/Export/CSV.pm
+++ b/cfg/plugins/EPrints/Plugin/Stats/Export/CSV.pm
@@ -10,7 +10,7 @@ use strict;
 # Export data to the CSV format. Note that numbers are output in a way that prevents MS Excel from formatting the value ($number -> ="$number")
 # 
 
-sub mimetype { 'text/plain' }
+sub mimetype { 'text/csv' }
 
 sub export
 {
@@ -23,14 +23,14 @@ sub export
 	my $header = $stats->data->[0];
 	if( defined $header )
 	{
-		print STDOUT join( ",", keys %$header )."\n";
+		print STDOUT join( ",", sort keys %$header )."\n";
 	}
 
         my @records;
         foreach my $data (@{$stats->data})
         {
                 my @record;
-                foreach my $k (keys %$data)
+                foreach my $k (sort keys %$data)
                 {
 			push @record, $self->escape_value( $data->{$k} );
                 }


### PR DESCRIPTION
In "sub export" you use "keys %$header" but you should use an ordered form like "sort keys %$header".
Same thing in "keys %$data" but you should use an ordered form like "sort keys %$data".
The first is on line 26 and the second is on line 33 on package EPrints::Plugin::Stats::Export::CSV.

Update the mimetype from text/plain to text/csv will be greatly appreciated (see issue #68 ).

See issue #72 and #68