### PR TITLE
The title of Screen::IRStats2::Report  should not change according to report you chose

### DIFF
--- a/cfg/plugins/EPrints/Plugin/Screen/IRStats2/Report.pm
+++ b/cfg/plugins/EPrints/Plugin/Screen/IRStats2/Report.pm
@@ -68,23 +68,6 @@ sub from
 	$processor->{stats}->{conf} = EPrints::Utils::clone( $conf );
 }
 
-sub render_title
-{
-	my( $self ) = @_;
-
-	my $processor = $self->{processor};
-
-	if( !defined $self->{processor}->{stats}->{handler} )
-	{
-		$self->from;
-	}
-
-	my $handler = $self->{processor}->{stats}->{handler} || $self->{session}->plugin( 'Stats::Handler' );
-
-	my $report = $processor->{context}->current_report;
-	return $self->{session}->html_phrase( "lib/irstats2:report:$report" );
-}
-
 sub render
 {
 	my( $self ) = @_;
@@ -107,7 +90,11 @@ sub render
 	{
 		return $self->html_phrase( 'invalid_set_value' );
 	}
-
+	my $report = $context->current_report;
+	my $divrep=$self->{session}->make_element('h2', class=>'ep_tm_pagetitle report_title');
+	$frag->appendChild($divrep);
+	$divrep->appendChild($self->{session}->html_phrase( "lib/irstats2:report:$report" ));
+	
 	foreach my $item ( @{$conf->{items} || []} )
 	{
 		my $pluginid = delete $item->{plugin};

--- a/cfg/static/style/auto/irstats2.css
+++ b/cfg/static/style/auto/irstats2.css
@@ -521,3 +521,7 @@ div.irstats2_options_dates, div.irstats2_options_filters, div.irstats2_options_r
 table.irstats2_view_Grid div.irstats2_view {
 	width: 97%;
 }
+.report_title {
+	text-align: center;
+	margin-top: 0px;
+}


### PR DESCRIPTION
If we enable the plugin `Screen::IRStats2::Report` the title is render by the "`sub render_title`" in `Screen::IRStats2::Report` that change with the report in "Available Reports".

I think that the title's plugin, on the menu bar, must be the same but we can add a sub title with the name of the report.
We can see all that in http://demoprints.eprints.org/cgi/stats/report and than click on "Available Reports"
than "Requests" or "Comparison per year"
