### PR TITLE
Avoid XSS vulnerability in some CGI output

### DIFF
--- a/cgi/stats/export
+++ b/cgi/stats/export
@@ -1,6 +1,7 @@
 use strict;
 
 use EPrints;
+require HTML::Entities;
 
 # format is:
 # /cgi/stats/export/<ExportPluginId>/...
@@ -37,7 +38,7 @@ unless(defined $dbh)
 my $export_plugin = $session->plugin( "Stats::Export::$export" );
 unless( defined $export_plugin )
 {
-	print STDOUT "<p>IRStats2: unknown export <strong>$export</strong></p>";
+	print STDOUT "<p>IRStats2: unknown export <strong>".HTML::Entities::encode( $export )."</strong></p>";
 	$session->terminate;
 	return;
 }

--- a/cgi/stats/get
+++ b/cgi/stats/get
@@ -1,6 +1,7 @@
 use strict;
 
 use EPrints;
+require HTML::Entities;
 
 my $session = new EPrints::Session;
 return unless( defined $session );
@@ -39,7 +40,7 @@ my $view_plugin = $session->plugin( "Stats::View::$view",
 
 unless( defined $view_plugin )
 {
-	print STDOUT "<p>IRStats2: unknown view <strong>$view</strong></p>";
+	print STDOUT "<p>IRStats2: unknown view <strong>".HTML::Entities::encode( $view )."</strong></p>";
 	$session->terminate;
 	return;
 }

--- a/cgi/stats/set_finder
+++ b/cgi/stats/set_finder
@@ -1,6 +1,7 @@
 use strict;
 
 use EPrints;
+require HTML::Entities;
 
 # This extension works only with Stats::View::SetDesc
 
@@ -91,7 +92,7 @@ foreach my $value ( @$values )
 		utf8::decode( $escape_value );
 		utf8::decode( $value->{rendered_set_value} );
 	}
-	$html .= "<li><div class='irstats2_setfinder_row'><a href='$base_url/$set_name/".EPrints::Utils::url_escape( $escape_value )."/$report'>".$value->{rendered_set_value}."</a></div></li>";
+	$html .= "<li><div class='irstats2_setfinder_row'><a href='$base_url/".HTML::Entities::encode( $set_name )."/".EPrints::Utils::url_escape( $escape_value )."/$report'>".$value->{rendered_set_value}."</a></div></li>";
 
 	$done_any++;
 }


### PR DESCRIPTION
If HTML::Entities is available, encode user variables before passing as HTML to prevent XSS.  Resolves https://github.com/eprints/irstats2/issues/80