### PR TITLE
eprints/irstats2#50: Add a Filter to blacklist by IP.  

### DIFF
--- a/cfg/plugins/EPrints/Plugin/Stats/Filter/Blacklist.pm
+++ b/cfg/plugins/EPrints/Plugin/Stats/Filter/Blacklist.pm
@@ -1,0 +1,50 @@
+package EPrints::Plugin::Stats::Filter::Blacklist;
+
+use EPrints::Plugin::Stats::Processor;
+
+our @ISA = qw/ EPrints::Plugin::Stats::Processor /;
+
+use strict;
+use NetAddr::IP;
+
+our @IPS = map { NetAddr::IP->new($_) } <DATA>;
+
+sub new
+{
+	my( $class, %params ) = @_;
+	my $self = $class->SUPER::new( %params );
+
+	$self->{disable} = 0;
+
+	return $self;
+}
+
+sub filter_record
+{
+	my ($self, $record) = @_;
+
+	my $id = $record->{requester_id};
+	return 0 unless( defined $id );
+	my $ip = NetAddr::IP->new($id);
+	return 0 unless( defined($ip) );
+
+	my $is_blacklisted = 0;
+	
+	for( @IPS )
+	{
+		$is_blacklisted = 1, last if $ip->within($_);
+	}
+
+	return $is_blacklisted;
+}
+
+
+1;
+
+__DATA__
+103.25.156.0/24
+103.36.96.0/24
+111.221.28.0/24
+123.125.71.0/24
+180.76.15.0/24
+202.89.235.0/24


### PR DESCRIPTION
Solves filtering local IP ranges and blacklisting bad robots that don't identify themselves by UA.  Initial IP selection drawn from https://wiki.eprints.org/w/images/3/36/Bad_robots.txt

Considerations:
- Should localhost IPs `127.0.0.1` and `::1` be include by default?
- This introduces a new requirement of CPAN package `NetAddr::IP`.
  - Should this fail more gracefully if not present?
  - Where should this new dependency be documented?
