### PR TITLE
Implements #87 using HTTP::BrowserDetect

### DIFF
--- a/cfg.d/z_irstats2.pl
+++ b/cfg.d/z_irstats2.pl
@@ -263,6 +263,35 @@ $c->{irstats2}->{allow} = sub {
 #UAs additional to http://www.eprints.org/resource/bad_robots/robots_ua.txt to not include in stats
 #$c->{irstats2}->{robots_ua} = [ ];
 
+# Browser signatures for use in classification by Stats::Processor::Access::Browsers
+#$c->{irstats2}->{browsers_signatures} = {
+#        '; AOL' => 'AOL',
+#        'Chrome\/' => 'Google Chrome',
+#        'Elinks\/' => 'Elinks',
+#        'Firefox\/' => 'Firefox',
+#        '; MSIE ' => 'Microsoft Internet Explorer',
+#        'Netscape\/' => 'Netscape',
+#        'Navigator\/' => 'Netscape',
+#        'Safari\/' => 'Apple Safari',
+#        '; Android ' => 'Android',
+#        '\(BlackBerry;' => 'BlackBerry',
+#        'Opera\/' => 'Opera',
+#        '; Opera Mobi\/' => 'Opera Mobile',
+#};
+#$c->{irstats2}->{browsers_signatures_order} = [
+#        '; AOL',
+#        'Chrome\/',
+#        'Elinks\/',
+#        'Firefox\/',
+#        '; MSIE ',
+#        'Netscape\/',
+#        'Navigator\/',
+#        'Safari\/',
+#        '; Android ',
+#        '\(BlackBerry;',
+#        'Opera\/',
+#        '; Opera Mobi\/',
+#];
 
 # time-out for the so-called "double-click" filtering - default to 3600 secs = 1 hour
 # Default setting - 3600 secs = 1 hour

--- a/plugins/EPrints/Plugin/Stats/Processor/Access/Browsers.pm
+++ b/plugins/EPrints/Plugin/Stats/Processor/Access/Browsers.pm
@@ -24,6 +24,21 @@ our $BROWSERS_SIGNATURES = {
 	'; Opera Mobi\/' => 'Opera Mobile',
 };
 
+our $BROWSERS_SIGNATURES_ORDER = [
+	'; AOL',
+	'Chrome\/',
+	'Elinks\/',
+	'Firefox\/',
+	'; MSIE ',
+	'Netscape\/',
+	'Navigator\/',
+        'Safari\/',
+        '; Android ',
+        '\(BlackBerry;',
+        'Opera\/',
+        '; Opera Mobi\/',
+];
+
 sub new
 {
         my( $class, %params ) = @_;
@@ -37,7 +52,23 @@ sub new
                 fields => [ 'value' ],
                 render => 'string',
         };
-	
+
+	if ( EPrints::Utils::require_if_exists( 'HTTP::BrowserDetect' ) )
+	{
+		$self->{conf}->{browser_cache} = {};
+	}
+	else
+	{
+		if ( $self->{session}->config( 'irstats2', 'browsers_signatures' ) )
+		{
+			$BROWSERS_SIGNATURES = $self->{session}->config( 'irstats2', 'browsers_signatures' );
+		}
+		if ( $self->{session}->config( 'irstats2', 'browsers_signatures_order' ) )
+		{
+			$BROWSERS_SIGNATURES_ORDER = $self->{session}->config( 'irstats2', 'browsers_signatures_order' );
+		}
+	}
+
 	return $self;
 }
 
@@ -51,24 +82,42 @@ sub process_record
 	my $ua = $record->{requester_user_agent};
 	return unless( EPrints::Utils::is_set( $ua ) );
 
-	my $found = 0;
 	my $date = $record->{datestamp}->{cache};
-	foreach( sort keys %$BROWSERS_SIGNATURES )
+
+
+	if ( defined $self->{conf}->{browser_cache} )
 	{
-		if( $ua =~ $_ )
+		my $browser;
+		if ( $self->{conf}->{browser_cache}->{$ua} )
 		{
-			$self->{cache}->{"$date"}->{$epid}->{$BROWSERS_SIGNATURES->{$_}}++;
-			$found = 1;
-			last;
+			$browser = $self->{conf}->{browser_cache}->{$ua};
+		}
+		else
+		{
+			my $browser_detect = HTTP::BrowserDetect->new( $ua );
+			$browser = $browser_detect->browser_string || 'Other';
+			$self->{conf}->{browser_cache}->{$ua} = $browser;
+		}
+		$self->{cache}->{"$date"}->{$epid}->{$browser}++;
+	}
+	else
+	{
+		my $found = 0;
+		foreach( @$BROWSERS_SIGNATURES_ORDER )
+		{
+			if( $ua =~ $_ )
+			{
+				$self->{cache}->{"$date"}->{$epid}->{$BROWSERS_SIGNATURES->{$_}}++;
+				$found = 1;
+				last;
+			}
+		}
+
+		if (not $found)
+		{
+			$self->{cache}->{"$date"}->{$epid}->{Other}++;
 		}
 	}
-
-	if (not $found)
-	{
-		$self->{cache}->{"$date"}->{$epid}->{Other}++;
-	}
-
-
 }
 
 1;


### PR DESCRIPTION
- Uses HTTP::BrowserDetect to get basic name of browser (e.g. Firefox, Google Chrome, Safari, etc.).
- Keeps fallback to old method if HTTP::BrowserDetect not installed.
- If using old method ensure consistent order and allows customisation in z_irstats2.pl